### PR TITLE
Adiciona catálogo de cursos front (Classpert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Contribuições são bem vindas.
 - [Front End Happy Hour](https://frontendhappyhour.com/)
 - [React Podcast](https://reactpodcast.simplecast.fm/)
 - [Syntax FM](https://syntax.fm/)
+- [Front End Online Courses](https://classpert.com/front-end)
 
 ## UX (pt-br 🇧🇷)
 


### PR DESCRIPTION
Esse commit adiciona na seção de podcasts / canais em inglês um link para um catálogo da Classpert de ~200 cursos de front (gratuitos e pagos) de grandes plataformas de e-learning como Udacity, Coursera, Pluralsight, Udemy, Edx, Treehouse, and Skillshare. Tem Alura que é pt-br mas fiquei em dúvida em qual seção colocar (dá pra filtrar por língua no site)